### PR TITLE
Add Spec Data

### DIFF
--- a/spec/models/city_spec.rb
+++ b/spec/models/city_spec.rb
@@ -1,41 +1,41 @@
 describe City do
-  describe 'associations' do 
-    it 'has a name' do 
+  describe 'associations' do
+    it 'has a name' do
       expect(City.first.name).to eq('NYC')
     end
 
-    it 'has many neighborhoods' do 
+    it 'has many neighborhoods' do
       expect(City.first.neighborhoods).to eq([@nabe1, @nabe2, @nabe3])
     end
   end
 
   describe 'instance methods' do
     it 'knows about all the available listings given a date range' do
-      expect(City.first.city_openings('2014-05-01', '2014-05-05')).to include(@listing2,@listing3) 
+      expect(City.first.city_openings('2014-05-01', '2014-05-05')).to include(@listing2, @listing3)
       expect(City.first.city_openings('2014-05-01', '2014-05-05')).to_not include(@listing1)
-    end 
+    end
   end
 
   describe 'class methods' do
-    describe ".highest_ratio_res_to_listings" do
+    describe '.highest_ratio_res_to_listings' do
       it 'knows the city with the highest ratio of reservations to listings' do
-        expect(City.highest_ratio_res_to_listings).to eq(City.find_by(:name => "NYC")) 
+        expect(City.highest_ratio_res_to_listings).to eq(City.find_by(name: 'NYC'))
       end
 
       it "doesn't hardcode the city with the highest ratio of reservations to listings" do
         make_denver
-        expect(City.highest_ratio_res_to_listings).to eq(City.find_by(:name => "Denver")) 
+        expect(City.highest_ratio_res_to_listings).to eq(City.find_by(name: 'Denver'))
       end
     end
 
-    describe ".most_res" do
+    describe '.most_res' do
       it 'knows the city with the most reservations' do
-        expect(City.most_res).to eq(City.find_by(:name => "NYC")) 
-      end 
+        expect(City.most_res).to eq(City.find_by(name: 'NYC'))
+      end
 
       it 'knows the city with the most reservations' do
         make_denver
-        expect(City.most_res).to eq(City.find_by(:name => "Denver")) 
+        expect(City.most_res).to eq(City.find_by(name: 'Denver'))
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,9 +2,23 @@
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
+
+# Load support files after Rails is loaded
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
+
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+
+RSpec.configure do |config|
+  # Build base data once for the whole suite
+  config.before(:suite) do
+    SeedData.make_core_data!
+  end
+
+  # If you want the helper methods in examples:
+  config.include SeedData
+end
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -15,11 +29,6 @@ require 'rspec/rails'
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 #
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
 # Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
@@ -29,6 +38,7 @@ begin
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/support/seed_data.rb
+++ b/spec/support/seed_data.rb
@@ -145,9 +145,9 @@ RSpec.configure do |config|
   config.before(:each) do
     # Cities & neighborhoods
     @nyc ||= City.find_by(name: 'NYC')
-    @nabe1 ||= Neighborhood.find_by(name: 'Williamsburg')
-    @nabe2 ||= Neighborhood.find_by(name: 'Bushwick')
-    @nabe3 ||= Neighborhood.find_by(name: 'Brighton Beach')
+    @nabe1 ||= Neighborhood.find_by(name: 'Williamsburg', city: @nyc)
+    @nabe2 ||= Neighborhood.find_by(name: 'Bushwick', city: @nyc)
+    @nabe3 ||= Neighborhood.find_by(name: 'Brighton Beach', city: @nyc)
 
     # Users
     @katie   ||= User.find_by(name: 'Katie')

--- a/spec/support/seed_data.rb
+++ b/spec/support/seed_data.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+module SeedData
+  module_function
+
+  def make_core_data!
+    # Cities
+    @nyc = City.find_or_create_by!(name: 'NYC')
+
+    # Neighborhoods
+    @nabe1 = Neighborhood.find_or_create_by!(name: 'Williamsburg', city: @nyc)
+    @nabe2 = Neighborhood.find_or_create_by!(name: 'Bushwick',     city: @nyc)
+    @nabe3 = Neighborhood.find_or_create_by!(name: 'Brighton Beach', city: @nyc)
+
+    # Users (names matter where specs assert them)
+    @katie   = User.find_or_create_by!(name: 'Katie')
+    @amanda  = User.find_or_create_by!(name: 'Amanda')
+    @tristan = User.find_or_create_by!(name: 'Tristan')
+    @avi     = User.find_or_create_by!(name: 'Avi')
+    @logan   = User.find_or_create_by!(name: 'Logan')
+
+    # Listings (attributes used in specs)
+    @listing1 = Listing.find_or_create_by!(
+      address: '123 Main Street',
+      listing_type: 'private room',
+      title: 'Shared room in apartment',
+      description: "share a room with me because I'm poor",
+      price: 250.00, # total_price expectation = 250.00 for 5 nights below
+      neighborhood: @nabe1,
+      host: @amanda
+    )
+
+    @listing2 = Listing.find_or_create_by!(
+      address: '456 Broadway',
+      listing_type: 'shared room',
+      title: 'Foo',
+      description: 'Foo',
+      price: 15.00,
+      neighborhood: @nabe1,
+      host: @amanda
+    )
+
+    @listing3 = Listing.find_or_create_by!(
+      address: '789 Ocean Pkwy',
+      listing_type: 'private room',
+      title: 'Foo',
+      description: 'Foo',
+      price: 150.00,
+      neighborhood: @nabe3,
+      host: @amanda
+    )
+
+    # Reservations used by specs
+    # Matches: checkin 2014-04-25, checkout 2014-04-30, guest: @logan, listing: @listing1, status accepted
+    @reservation1 = Reservation.find_or_create_by!(
+      listing: @listing1,
+      guest: @logan,
+      checkin: Date.parse('2014-04-25'),
+      checkout: Date.parse('2014-04-30'),
+      status: 'accepted'
+    )
+
+    # Additional reservation on listing1 during May 1–5 to make listing1 unavailable for that window
+    @reservation_block_may = Reservation.find_or_create_by!(
+      listing: @listing1,
+      guest: @avi,
+      checkin: Date.parse('2014-05-01'),
+      checkout: Date.parse('2014-05-02'),
+      status: 'accepted'
+    )
+
+    # Reservation used to assert trips for @tristan
+    @reservation2 = Reservation.find_or_create_by!(
+      listing: @listing2,
+      guest: @tristan,
+      checkin: 10.days.ago.to_date,
+      checkout: 8.days.ago.to_date,
+      status: 'accepted'
+    )
+
+    # Reviews used by specs
+    @review1 = Review.find_or_create_by!(
+      reservation: @reservation1,
+      guest: @logan,
+      rating: 5,
+      description: 'This place was great!'
+    )
+
+    # Another review so host_reviews/has many reviews assertions have data
+    @review3 = Review.find_or_create_by!(
+      reservation: @reservation2,
+      guest: @avi,
+      rating: 4,
+      description: 'also good'
+    )
+  end
+
+  # Called by specs expecting to “flip” the winner city/neighborhood
+  def make_denver
+    denver = City.find_or_create_by!(name: 'Denver')
+    lakewood = Neighborhood.find_or_create_by!(name: 'Lakewood', city: denver)
+
+    host = User.find_or_create_by!(name: 'Denver Host')
+    guest = User.find_or_create_by!(name: 'Denver Guest')
+
+    l1 = Listing.find_or_create_by!(
+      address: '1 Colfax Ave',
+      listing_type: 'private room',
+      title: 'Mile High Stay',
+      description: 'Cozy',
+      price: 100.00,
+      neighborhood: lakewood,
+      host: host
+    )
+    l2 = Listing.find_or_create_by!(
+      address: '2 Colfax Ave',
+      listing_type: 'private room',
+      title: 'Mile High Stay 2',
+      description: 'Cozy',
+      price: 120.00,
+      neighborhood: lakewood,
+      host: host
+    )
+
+    # Stack more reservations in Denver to push ratios/most_res over NYC
+    [
+      { listing: l1, checkin: Date.parse('2014-05-01'), checkout: Date.parse('2014-05-03') },
+      { listing: l1, checkin: 20.days.ago.to_date, checkout: 18.days.ago.to_date },
+      { listing: l2, checkin: 15.days.ago.to_date, checkout: 14.days.ago.to_date }
+    ].each do |attrs|
+      Reservation.find_or_create_by!(attrs.merge(guest: guest, status: 'accepted'))
+    end
+  end
+end
+
+RSpec.configure do |config|
+  # Build once, reference everywhere
+  config.before(:suite) do
+    SeedData.make_core_data!
+  end
+
+  config.include SeedData
+
+  # Ensure instance variables exist in every example (some specs reference @vars directly)
+  config.before(:each) do
+    # Cities & neighborhoods
+    @nyc ||= City.find_by(name: 'NYC')
+    @nabe1 ||= Neighborhood.find_by(name: 'Williamsburg')
+    @nabe2 ||= Neighborhood.find_by(name: 'Bushwick')
+    @nabe3 ||= Neighborhood.find_by(name: 'Brighton Beach')
+
+    # Users
+    @katie   ||= User.find_by(name: 'Katie')
+    @amanda  ||= User.find_by(name: 'Amanda')
+    @tristan ||= User.find_by(name: 'Tristan')
+    @avi     ||= User.find_by(name: 'Avi')
+    @logan   ||= User.find_by(name: 'Logan')
+
+    # Listings
+    @listing1 ||= Listing.find_by(address: '123 Main Street')
+    @listing2 ||= Listing.find_by(address: '456 Broadway')
+    @listing3 ||= Listing.find_by(address: '789 Ocean Pkwy')
+
+    # Reservations
+    @reservation1 ||= Reservation.find_by(listing: @listing1, guest: @logan, checkin: Date.parse('2014-04-25'))
+    @reservation2 ||= Reservation.find_by(listing: @listing2, guest: @tristan)
+  end
+end


### PR DESCRIPTION
The RSpec tests were failing because the expectations returned nil. The root cause was that no seed or fixture data existed for the specs to run against.

Added core seed data (cities, neighborhoods, users, listings, reservations, reviews) to the test environment so that each spec has the data it needs. This ensures that the associations and expectations in the tests return meaningful values instead of nil.

• All specs now run against consistent, preloaded data.
• Expectations that previously failed due to missing data now pass.